### PR TITLE
SIGINT-2519: Unable to execute CoP Scans successfully with the new Blackduck Coverity on Polaris Jenkins Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <revision>2.0.0</revision>
-    <changelist>-QA1</changelist>
+    <changelist>-QA2</changelist>
     <jenkins.version>2.440.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/com/blackduck/integration/jenkins/polaris/service/PolarisCliVersionHandler.java
+++ b/src/main/java/com/blackduck/integration/jenkins/polaris/service/PolarisCliVersionHandler.java
@@ -28,14 +28,14 @@ public class PolarisCliVersionHandler {
     }
 
     /**
-     * Compares two Polaris CLI version strings in the format "X.Y.Z" (e.g., "1.0.1").
+     * Compares two Polaris CLI version strings in the format "YYYY.MM.P" (e.g., "2024.9.0").
      *
-     * @param version1 the first version string to compare, in the format "X.Y.Z"
-     * @param version2 the second version string to compare, in the format "X.Y.Z"
+     * @param version1 the first version string to compare, in the format "YYYY.MM.P"
+     * @param version2 the second version string to compare, in the format "YYYY.MM.P"
      * @return an integer that is:
      *         - Negative if version1 is less than version2
      *         - Zero if version1 is equal to version2
-     *         - Positive if version1 is greater than version2
+     *         - Positive if version1 is greater than version2 or major part of the version2 is less than length of 4
      *
      * If either of the versions does not have exactly three components (major, minor, patch),
      * the method returns 1, implying an invalid version format.
@@ -44,7 +44,8 @@ public class PolarisCliVersionHandler {
         String[] ver1Parts = version1.split("\\.");
         String[] ver2Parts = version2.split("\\.");
 
-        if (ver1Parts.length != 3 && ver2Parts.length != 3) {
+        // ver1Parts[0].length() < 4 check is included to support the CLI dev build versions (example - 1.24.31)
+        if ((ver1Parts.length != 3 && ver2Parts.length != 3) || ver1Parts[0].length() < 4) {
             return 1;
         }
 

--- a/src/test/java/com/blackduck/integration/jenkins/polaris/service/PolarisCliVersionHandlerTest.java
+++ b/src/test/java/com/blackduck/integration/jenkins/polaris/service/PolarisCliVersionHandlerTest.java
@@ -84,4 +84,14 @@ public class PolarisCliVersionHandlerTest {
 
         assertTrue(result > 0, "Version 2023.5.1 should be greater than 2023.5.0.");
     }
+
+    @Test
+    public void testComparePolarisVersions_DevBuildVersion() {
+        String version1 = "1.24.33";
+        String version2 = "2023.9.0";
+
+        int result = versionHandler.comparePolarisVersions(version1, version2);
+
+        assertTrue(result > 0, "Version 1.24.33 should be greater than 2023.5.0.");
+    }
 }

--- a/src/test/java/com/blackduck/integration/polaris/common/service/JobServiceTest.java
+++ b/src/test/java/com/blackduck/integration/polaris/common/service/JobServiceTest.java
@@ -17,6 +17,7 @@ import com.blackduck.integration.rest.request.Request;
 import com.blackduck.integration.rest.response.Response;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,11 @@ public class JobServiceTest {
     }
 
     private String getPreparedContentStringFrom(String resourceName) throws IOException {
-        return IOUtils.toString(getClass().getResourceAsStream("/JobService/" + resourceName), StandardCharsets.UTF_8);
+        try (InputStream inputStream = getClass().getResourceAsStream("/JobService/" + resourceName)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + resourceName);
+            }
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        }
     }
 }

--- a/src/test/java/com/blackduck/integration/polaris/common/service/PolarisServiceTest.java
+++ b/src/test/java/com/blackduck/integration/polaris/common/service/PolarisServiceTest.java
@@ -23,6 +23,7 @@ import com.blackduck.integration.rest.response.Response;
 import com.blackduck.integration.rest.support.AuthenticationSupport;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -189,7 +190,11 @@ public class PolarisServiceTest {
     }
 
     private String getPreparedContentStringFrom(String resourceName) throws IOException {
-        return IOUtils.toString(
-                getClass().getResourceAsStream("/PolarisService/" + resourceName), StandardCharsets.UTF_8);
+        try (InputStream inputStream = getClass().getResourceAsStream("/PolarisService/" + resourceName)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + resourceName);
+            }
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        }
     }
 }


### PR DESCRIPTION
- Fixed issue for executing CoP Scans successfully with the new Blackduck Coverity on Polaris Jenkins Plugin using CLI dev build
- Addressed POP Coverity issues in unit tests